### PR TITLE
Small changes to turbulent channel

### DIFF
--- a/turbulent_channel_flow_dns.jl
+++ b/turbulent_channel_flow_dns.jl
@@ -1,10 +1,12 @@
 using Oceananigans
 
+chebychev_spaced_z_faces(k) = - cos(π * (k - 1) / Nz)
+
 grid = RectilinearGrid(GPU(),
                        size=(512, 256, 256),
-                       x = (0, 4π)
-                       y = (-π, π)
-                       z = (-1, 1)
+                       x = (0, 4π),
+                       y = (-π, π),
+                       z = chebychev_spaced_z_faces,
                        topology = (Periodic, Periodic, Bounded))
 
 no_slip = ValueBoundaryCondition(0)


### PR DESCRIPTION
I have made a couple of changes to follow the [KMM paper](https://www.cambridge.org/core/services/aop-cambridge-core/content/view/308DCF387F4488D6A0FB189D8206DF7B/S0022112087000892a.pdf/turbulence-statistics-in-fully-developed-channel-flow-at-low-reynolds-number.pdf). Probably we also need time averaging, but that depends on the results, if the results are ok with only spatial averaging, we can keep it like this.